### PR TITLE
Royal Blue Palette

### DIFF
--- a/styles/colors/royal-blue.json
+++ b/styles/colors/royal-blue.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"title": "Royal Blue",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"name": "Brand",
+					"slug": "primary",
+					"color": "#1E3A8A"
+				},
+				{
+					"name": "Brand Accent",
+					"slug": "primary-accent",
+					"color": "#4F68C6"
+				},
+				{
+					"name": "Brand Alt",
+					"slug": "primary-alt",
+					"color": "#B1C2FF"
+				},
+				{
+					"name": "Brand Alt Accent",
+					"slug": "primary-alt-accent",
+					"color": "#263042"
+				},
+				{
+					"name": "Contrast",
+					"slug": "main",
+					"color": "#171A1F"
+				},
+				{
+					"name": "Contrast Accent",
+					"slug": "main-accent",
+					"color": "#B6C7D9"
+				},
+				{
+					"name": "Base",
+					"slug": "base",
+					"color": "#FFFFFF"
+				},
+				{
+					"name": "Base Accent",
+					"slug": "secondary",
+					"color": "#3B5570"
+				},
+				{
+					"name": "Tint",
+					"slug": "tertiary",
+					"color": "#F8F7F9"
+				},
+				{
+					"name": "Border Base",
+					"slug": "border-light",
+					"color": "#DADEE3"
+				},
+				{
+					"name": "Border Contrast",
+					"slug": "border-dark",
+					"color": "#444B57"
+				}
+			]
+		}
+	}
+}

--- a/theme.json
+++ b/theme.json
@@ -17,6 +17,14 @@
 					]
 				},
 				{
+					"name": "Royal Blue",
+					"slug": "royal-blue",
+					"colors": [
+						"#1E3A8A",
+						"#4F68C6"
+					]
+				},
+				{
 					"name": "Pink",
 					"slug": "Pink",
 					"colors": [
@@ -115,6 +123,11 @@
 					"name": "Blue",
 					"slug": "blue",
 					"gradient": "linear-gradient(135deg, #0057FF, #31B5FF)"
+				},
+				{
+					"name": "Royal Blue",
+					"slug": "royal-blue",
+					"gradient": "linear-gradient(135deg, #1E3A8A, #4F68C6)"
 				},
 				{
 					"name": "Pink",


### PR DESCRIPTION
This pull request introduces a new color theme named "Royal Blue" to the project. The changes include defining the color palette for the new theme and updating the `theme.json` file to incorporate the new theme.

Key changes include:

Theme definition:

* [`styles/colors/royal-blue.json`](diffhunk://#diff-6975566eaf62978befeee97baf2f2f522a8321310d324df485f9165a076d9fffR1-R66): Added a new JSON file defining the "Royal Blue" theme with a detailed color palette.

Theme integration:

* [`theme.json`](diffhunk://#diff-160c735a986cf8c05e1f6b2e9ac89dd0410562d2fe5ccbdc93157bd92f3dc2bcR19-R26): Added the "Royal Blue" theme to the list of available themes, including its primary and accent colors.
* [`theme.json`](diffhunk://#diff-160c735a986cf8c05e1f6b2e9ac89dd0410562d2fe5ccbdc93157bd92f3dc2bcR127-R131): Added a gradient definition for the "Royal Blue" theme.