### PR TITLE
Old Branding Removal README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Moiraine — A WordPress Block Theme
 
-![Image](https://user-images.githubusercontent.com/1415737/217930880-5d019715-f0c2-4f2f-9d24-dd466abf531b.jpg)
-
 Moiraine is a modern WordPress block theme designed to work seamlessly with the WordPress block editor and site editor, where you can create beautiful, fully-customizable websites with WordPress's built-in page builder — no page builder or coding skills required.
 
 Moiraine ships with over 50 beautifully-designed patterns, page templates, block styles, and style variations so you can design stunning pages quickly with drag and drop instead of code. Moiraine is also blazing fast, fully customizable via the WordPress UI, fully responsive out of the box, and scores 100% across the board on performance.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes an image from the documentation. 

Changes in documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L4): Removed the image link from the beginning of the file.