### PR TITLE
WordPress Standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "phpcompatibility/phpcompatibility-wp": "^2.1"
 	},
 	"scripts": {
-		"lint": "@php ./vendor/bin/parallel-lint --exclude .git --exclude vendor .",
-		"wpcs:scan": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/vendor/* --standard=WordPress-Extra .",		
-		"wpcs:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --ignore=*/vendor/* --standard=WordPress-Extra ."
+		"lint": "@php ./vendor/bin/parallel-lint --exclude .git --exclude vendor --exclude patterns .",
+		"wpcs:scan": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/vendor/*,*/patterns/* --standard=WordPress .",        
+    "wpcs:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --ignore=*/vendor/*,*/patterns/* --standard=WordPress ."
 		
 	},
 	"config": {


### PR DESCRIPTION
This pull request includes updates to the `composer.json` file to improve the linting and code scanning scripts. The most important changes involve excluding the `patterns` directory from the linting and WordPress Coding Standards (WPCS) checks.

Improvements to linting and code scanning scripts:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R23): Updated the `lint` script to exclude the `patterns` directory.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R23): Updated the `wpcs:scan` and `wpcs:fix` scripts to exclude the `patterns` directory and changed the coding standard to `WordPress`.