### PR TITLE
PHP CS XML Config File

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Moiraine Theme">
+    <description>Coding standards for Moiraine Theme</description>
+
+    <!-- Use WordPress standards -->
+    <rule ref="WordPress" />
+
+    <!-- Exclude pattern files -->
+    <exclude-pattern>/patterns/*</exclude-pattern>
+    <exclude-pattern>/vendor/*</exclude-pattern>
+    
+    <!-- Additional exclusions if needed -->
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>*.css</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
This pull request introduces a new `phpcs.xml` file to enforce coding standards for the Moiraine Theme. The most important changes include setting up WordPress coding standards and excluding specific file patterns from the checks.

Configuration of coding standards:

* [`phpcs.xml`](diffhunk://#diff-daa856500eea114bbf034fd35b7600050d965e5d19bb0700885c075747848fd8R1-R15): Added a new ruleset for the Moiraine Theme, specifying the use of WordPress coding standards and excluding certain file patterns such as `/patterns/*`, `/vendor/*`, `*.js`, and `*.css`.