### PR TITLE
Menu Mobile Part Patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules/
 fsestudio-data.json
 
 /vendor/
+.rsync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Moiraine WordPress theme will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2025-09-24
+
+### Fixed
+- **Template Part Pattern Reference**: Fixed `parts/menu-mobile-simple.html` referencing incorrect pattern slug `moiraine/menu-mobile-1` instead of the correct `moiraine/mobile-menu-1`, which was preventing the mobile menu pattern from loading
+
 ## [2.1.1] - 2025-09-23
 
 ### Updated

--- a/parts/menu-mobile-simple.html
+++ b/parts/menu-mobile-simple.html
@@ -1,1 +1,1 @@
-<!-- wp:pattern {"slug":"moiraine/menu-mobile-1"} /-->
+<!-- wp:pattern {"slug":"moiraine/mobile-menu-1"} /-->

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blog, portfolio, entertainment, grid-layout, one-column, two-columns, thre
 Requires at least: 5.8
 Tested up to: 6.7.1
 Requires PHP: 7.3
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 License: GNU General Public License v3.0 (or later)
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -13,6 +13,9 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Launch a blazing-fast, pixel-perfect website with the Moiraine WordPress block theme! Moiraine features over 50 beautiful pattern designs, 7 full-page pattern layouts, and a fully-customizable design system with Global Styles. Moiraine integrates seamlessly with all of the powerful new WordPress editor features, giving you the most lightweight and powerful website builder on the planet — no expensive page builder plugin required! ✶ Full demo: https://demo.imagewize.com ✶
 
 == Changelog ==
+
+= 2.1.2 - 09/24/25 =
+* FIXED: Template part pattern reference - fixed parts/menu-mobile-simple.html referencing incorrect pattern slug moiraine/menu-mobile-1 instead of the correct moiraine/mobile-menu-1, which was preventing the mobile menu pattern from loading
 
 = 2.1.1 - 09/23/25 =
 * UPDATED: Menu Designer Block dependencies - updated npm dependencies including Playwright (1.55.0 → 1.55.1), Sass (1.93.0 → 1.93.1), and various @cacheable packages for improved performance and security

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: Launch a blazing-fast, pixel-perfect website with the Moiraine Word
 Tags: blog, portfolio, entertainment, grid-layout, one-column, two-columns, three-columns, four-columns, block-patterns, block-styles, custom-logo, custom-menu, editor-style, featured-images, full-site-editing, full-width-template, rtl-language-support, style-variations, template-editing, theme-options, translation-ready, wide-blocks
 Tested up to: 6.7.1
 Requires PHP: 7.3
-Version: 2.1.1
+Version: 2.1.2
 License: GNU General Public License v3 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: moiraine


### PR DESCRIPTION
This pull request addresses a bug where the mobile menu pattern was not loading due to an incorrect pattern slug reference in the `parts/menu-mobile-simple.html` file. The fix updates the pattern slug to the correct value and bumps the theme version to `2.1.2` across relevant files. Documentation has also been updated to reflect this change.

Bug Fix:

* Corrected the pattern slug in `parts/menu-mobile-simple.html` from `moiraine/menu-mobile-1` to `moiraine/mobile-menu-1`, resolving the issue that prevented the mobile menu pattern from loading.

Version and Documentation Updates:

* Updated the version to `2.1.2` in `style.css` and `readme.txt` to reflect the bug fix release [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL10-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7).
* Added a changelog entry in both `CHANGELOG.md` and `readme.txt` documenting the fixed pattern reference [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R17-R19).